### PR TITLE
Add eink display support to mnml collection

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -63,5 +63,7 @@ export const config: Config = {
         "black-atom-mnml-mikado-light": "./themes/mnml/black-atom-mnml-mikado-light",
         "black-atom-mnml-47-light": "./themes/mnml/black-atom-mnml-47-light",
         "black-atom-mnml-47-dark": "./themes/mnml/black-atom-mnml-47-dark",
+        "black-atom-mnml-eink-dark": "./themes/mnml/black-atom-mnml-eink-dark",
+        "black-atom-mnml-eink-light": "./themes/mnml/black-atom-mnml-eink-light",
     },
 };

--- a/src/themes/mnml/black-atom-mnml-eink-dark.ts
+++ b/src/themes/mnml/black-atom-mnml-eink-dark.ts
@@ -1,0 +1,58 @@
+import * as Theme from "../../types/theme.ts";
+import { oklch } from "../../utils/color.ts";
+
+import basePalette from "./base_palette.ts";
+import syntax from "./syntax_dark.ts";
+import ui from "./ui_dark.ts";
+
+const meta: Theme.Meta = {
+    key: "black-atom-mnml-eink-dark",
+    label: "Black Atom — MNM ∷ E-Ink Dark",
+    appearance: "dark",
+    status: "development",
+    collection: {
+        key: "mnml",
+        label: "MNM",
+    },
+};
+
+const primaries: Theme.Primaries = {
+    d10: oklch(0.26, 0, 0),
+    d20: oklch(0.32, 0, 0),
+    d30: oklch(0.36, 0, 0),
+    d40: oklch(0.40, 0, 0),
+
+    m10: oklch(0.46, 0, 0),
+    m20: oklch(0.52, 0, 0),
+    m30: oklch(0.56, 0, 0),
+    m40: oklch(0.60, 0, 0),
+
+    l10: oklch(0.65, 0, 0),
+    l20: oklch(0.70, 0, 0),
+    l30: oklch(0.76, 0, 0),
+    l40: oklch(0.83, 0, 0),
+};
+
+const accents: Theme.MnmlAccents = {
+    a10: oklch(0.76, 0.02, 0),
+    a20: oklch(0.65, 0.01, 0),
+};
+
+const palette = basePalette(primaries);
+
+const feedback: Theme.MnmlFeedback = {
+    negative: oklch(0.68, 0.13, 20),
+    success: oklch(0.76, 0.09, 120),
+    info: oklch(0.74, 0.07, 180),
+    warning: oklch(0.78, 0.09, 80),
+};
+
+const theme: Theme.Definition = {
+    meta,
+    primaries,
+    palette,
+    ui: ui(primaries, feedback, accents),
+    syntax: syntax(primaries, feedback, accents),
+};
+
+export default theme;

--- a/src/themes/mnml/black-atom-mnml-eink-light.ts
+++ b/src/themes/mnml/black-atom-mnml-eink-light.ts
@@ -1,0 +1,58 @@
+import * as Theme from "../../types/theme.ts";
+import { oklch } from "../../utils/color.ts";
+
+import basePalette from "./base_palette.ts";
+import syntax from "./syntax_light.ts";
+import ui from "./ui_light.ts";
+
+const meta: Theme.Meta = {
+    key: "black-atom-mnml-eink-light",
+    label: "Black Atom — MNM ∷ E-Ink Light",
+    appearance: "light",
+    status: "development",
+    collection: {
+        key: "mnml",
+        label: "MNM",
+    },
+};
+
+const primaries: Theme.Primaries = {
+    d10: oklch(0.26, 0, 0),
+    d20: oklch(0.32, 0, 0),
+    d30: oklch(0.38, 0, 0),
+    d40: oklch(0.44, 0, 0),
+
+    m10: oklch(0.48, 0, 0),
+    m20: oklch(0.52, 0, 0),
+    m30: oklch(0.56, 0, 0),
+    m40: oklch(0.60, 0, 0),
+
+    l10: oklch(0.88, 0, 0),
+    l20: oklch(0.91, 0, 0),
+    l30: oklch(0.94, 0, 0),
+    l40: oklch(0.97, 0, 0),
+};
+
+const accents: Theme.MnmlAccents = {
+    a10: oklch(0.45, 0.02, 0),
+    a20: oklch(0.55, 0.01, 0),
+};
+
+const palette = basePalette(primaries);
+
+const feedback: Theme.MnmlFeedback = {
+    negative: oklch(0.62, 0.21, 25),
+    success: oklch(0.65, 0.17, 120),
+    info: oklch(0.58, 0.11, 175),
+    warning: oklch(0.72, 0.16, 80),
+};
+
+const theme: Theme.Definition = {
+    meta,
+    primaries,
+    palette,
+    ui: ui(primaries, feedback, accents),
+    syntax: syntax(primaries, feedback, accents),
+};
+
+export default theme;

--- a/src/types/theme.ts
+++ b/src/types/theme.ts
@@ -28,6 +28,8 @@ export const themeKeys = [
     "black-atom-mnml-mikado-light",
     "black-atom-mnml-47-light",
     "black-atom-mnml-47-dark",
+    "black-atom-mnml-eink-dark",
+    "black-atom-mnml-eink-light",
 ] as const;
 
 type Key = (typeof themeKeys)[number];
@@ -67,7 +69,9 @@ interface Meta {
         | "Black Atom — MNM ∷ 47 Light"
         | "Black Atom — MNM ∷ 47 Dark"
         | "Black Atom — MNM ∷ Mikado Dark"
-        | "Black Atom — MNM ∷ Mikado Light";
+        | "Black Atom — MNM ∷ Mikado Light"
+        | "Black Atom — MNM ∷ E-Ink Dark"
+        | "Black Atom — MNM ∷ E-Ink Light";
     appearance: "light" | "dark";
     status: "development" | "beta" | "release";
     collection: {


### PR DESCRIPTION
Add dark and light e-ink theme variants featuring:
- Pure grayscale primaries (zero chroma) for true neutral gray
- Everforest-derived feedback colors for semantic elements
- Based on e-ink colorscheme with 16-step grayscale range